### PR TITLE
Update the stack LTS and fix a warning regarding fdSocket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work/

--- a/Examples/DHT-SimpleNode/DHT/SimpleNode/Messaging.hs
+++ b/Examples/DHT-SimpleNode/DHT/SimpleNode/Messaging.hs
@@ -111,9 +111,7 @@ sendF messagingState (maxPortLength,ourPort) address bs = case extractIPV4UDP ad
 
                   sock <- socket ipv4 Datagram udp
                   connect sock $ addrAddress inetAddr
-
-                  setCloseOnExecIfNeeded $ fdSocket sock
-
+                  setCloseOnExecIfNeeded <$> unsafeFdSocket sock
                   return (sock, state{_msgStateSocketsOut = Map.insert address sock $ _msgStateSocketsOut state})
 
     -- given a Port (represented by an Int), pad it with the appropriate number of leading zeros

--- a/Examples/DHT-SimpleNode/stack.yaml
+++ b/Examples/DHT-SimpleNode/stack.yaml
@@ -1,10 +1,9 @@
-resolver: lts-9.18
+resolver: lts-15.11
 
 packages:
 - '.'
 - '../../'
 extra-deps:
-- network-2.7.0.2
 
 flags: {}
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,8 @@
-resolver: lts-13.1
+resolver: lts-15.11
 
 packages:
-- '.'
+- .
+
 extra-deps: []
 
 flags: {}


### PR DESCRIPTION
@syallop Hi!
This PR  updates the LTS to 15.11, effectively using GHC-8.8.3.
Moreover, a line of code in the example had a compilation error that I fixed. Indeed, `fdSocket` is deprecated, in favour of `withFdSocket` or `unsafeFdSocket`. I used the latter since it matched closely what you were doing.